### PR TITLE
fixed name of _reveal-slides directory in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ First, [install Jekyll][]. After that, clone this repository and create a branch
 
 Clean the Example presentation:
 
-    git rm _reveal_slides/*
-    mkdir _reveal_slides
+    git rm _reveal-slides/*
+    mkdir _reveal-slides
 
 Or create a new folder.
 


### PR DESCRIPTION
The `README.md` listed the include directory as `_reveal_slides` but the underscore is actually a dash `_reveal-slides`. Making this change lets you cut and paste the commands.